### PR TITLE
Index xlink:href property as value

### DIFF
--- a/slurp_all_MODS_to_solr.xslt
+++ b/slurp_all_MODS_to_solr.xslt
@@ -5,6 +5,7 @@
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:foxml="info:fedora/fedora-system:def/foxml#"
   xmlns:mods="http://www.loc.gov/mods/v3"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
      exclude-result-prefixes="mods java">
   <!-- <xsl:include href="/usr/local/fedora/tomcat/webapps/fedoragsearch/WEB-INF/classes/config/index/FgsIndex/islandora_transforms/library/xslt-date-template.xslt"/>-->
   <xsl:include href="/usr/local/fedora/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/library/xslt-date-template.xslt"/>
@@ -329,6 +330,14 @@
           <xsl:value-of select="concat($prefix, 'valueURI_', $suffix)"/>
         </xsl:attribute>
         <xsl:value-of select="$node/@valueURI"/>
+      </field>
+    </xsl:if>
+    <xsl:if test="normalize-space($node/@xlink:href)">
+      <field>
+        <xsl:attribute name="name">
+          <xsl:value-of select="concat($prefix, 'xlinkhref_', $suffix)"/>
+        </xsl:attribute>
+        <xsl:value-of select="$node/@xlink:href"/>
       </field>
     </xsl:if>
 


### PR DESCRIPTION
many MODS elements allow xlink:href properties. This simple pull allows those to be indexed as Solr fields / values 
